### PR TITLE
Upgrade jansi to latest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val root = (project in file("."))
     name := "jline",
     autoScalaLibrary := false,
     crossPaths := false,
-    libraryDependencies += "org.fusesource.jansi" % "jansi" % "1.12",
+    libraryDependencies += "org.fusesource.jansi" % "jansi" % "2.0.1",
     libraryDependencies ++= Seq(
       junit % Test,
       easymock % Test,
@@ -23,6 +23,7 @@ val root = (project in file("."))
     Compile / javacOptions ++= Seq("-source", "1.6", "-target", "1.6"),
     Compile / doc / javacOptions := Nil,
     Test / parallelExecution := false,
+    Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Flat,
   )
 
 ThisBuild / organization := "org.scala-sbt.jline"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.12
+sbt.version=1.4.3

--- a/src/main/java/jline/internal/Ansi.java
+++ b/src/main/java/jline/internal/Ansi.java
@@ -12,6 +12,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import org.fusesource.jansi.AnsiOutputStream;
+import org.fusesource.jansi.AnsiProcessor;
 
 /**
  * Ansi support.
@@ -25,7 +26,7 @@ public class Ansi {
         if (str == null) return "";
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            AnsiOutputStream aos = new AnsiOutputStream(baos);
+            AnsiOutputStream aos = new AnsiOutputStream(baos, new AnsiProcessor(baos));
             aos.write(str.getBytes());
             aos.close();
             return baos.toString();


### PR DESCRIPTION
The latest version of jansi that jline 3 now uses breaks binary
compatibility relative to the jline 2 jansi version. This commit both
bumps the jansi version and fixes the broken binary compatibility. The
advantage to this is that we should hopefully be able to upgrade jline3
(and transitively jansi) in the future without worrying about breaking
the 2.12 console and the thin client (which graalvm has problems
compiling with the missing apis).